### PR TITLE
Write to &fe4f rather than &fe41.

### DIFF
--- a/lib/vgcplayer.asm
+++ b/lib/vgcplayer.asm
@@ -132,7 +132,7 @@ ENDIF
 {
     ldx #255
     stx &fe43
-    sta &fe41
+    sta &fe4f
     inx
     stx &fe40
     lda &fe40

--- a/lib/vgmplayer.asm
+++ b/lib/vgmplayer.asm
@@ -351,7 +351,7 @@ IF VGM_ENABLE_AUDIO
 	ldy #255
 	sty $fe43
 	
-	sta $fe41
+	sta $fe4f
 	lda #0
 	sta $fe40
 	nop


### PR DESCRIPTION
Writing to &fe41 clears the CA1 IRQ flag.